### PR TITLE
Add entitlements and remove unused plist key

### DIFF
--- a/ios/config.json
+++ b/ios/config.json
@@ -10,10 +10,12 @@
   "additionalLinkerFlags": [
     "-ObjC"
   ],
-  "userDefined": [
-    "onesignalAppID"
-  ],
   "plist": {
-    "onesignalAppID": "$(onesignal.onesignalAppID)"
+    "UIBackgroundModes": [
+      "remote-notification"
+    ]
+  },
+  "entitlements": {
+    "aps-environment": "production"
   }
 }


### PR DESCRIPTION
- Push notification entitlements enabled
- Background modes will be enabled
- Unused value in plist onesignalAppID
